### PR TITLE
Fixed bug with MT stuff

### DIFF
--- a/primitive_pv.py
+++ b/primitive_pv.py
@@ -31,13 +31,11 @@ class Prover:
 		# code to build MT
 		#self.mt = trees.MerkleNode(self.p.list_values())
 		self.mt = shelve.open(filename)
-		self.mt["leaf_values"] = [""]*self.p.size()
 		self.p.reset_seek()
 		print self.p.size()
 		for i in range(self.p.size()):
-			self.mt["leaf_values"][i] = self.p.read_value_noseek() # self.mt["leaf_values"] are all unhashed
-			print self.mt["leaf_values"][i] # FOR DEBUGGING -- @john the problem is here; self.p.read_value_noseek() seems to return ""
-		# print len(self.mt["leaf_values"])
+			s = self.p.read_value_noseek()
+			self.mt["leaf"+str(i)] = s # these values are all unhashed
 		self.mt["leaf_keys"] = trees.MT([0, self.p.size()], self.mt, "")
 
 		if self.debug:
@@ -49,7 +47,7 @@ class Prover:
 		return self.mt[""][0]
 
 	def open(self, i):
-		leaf_value = utils.secure_hash(self.mt["leaf_values"][i])
+		leaf_value = utils.secure_hash(self.mt["leaf"+str(i)])
 		if self.debug:
 			print "P: Opening that vertex, which has value "+leaf_value
 		sibling_path = trees.mtopen(i, self.mt)

--- a/trees.py
+++ b/trees.py
@@ -7,9 +7,9 @@ def MT(leaf_range, shelf, key, prehashed=False): # recursively generates merkle 
 	value = None
 	if size == 1: # if it is a leaf
 		if prehashed:
-			value = shelf["leaf_values"][leaf_range[0]]
+			value = shelf["leaf"+str(leaf_range[0])]
 		else:
-			value = utils.secure_hash(shelf["leaf_values"][leaf_range[0]])
+			value = utils.secure_hash(shelf["leaf"+str(leaf_range[0])])
 		shelf[key] = [value, leaf_range, True]
 		return [key]
 	else:


### PR DESCRIPTION
I was using shelf["leaf_values"] as a mutable array, but apparently one
cannot modify individual elements of this array.  Workaround has been
implemented; code should work now.
